### PR TITLE
fix: Discordメンバー取得の無限ループ問題を修正

### DIFF
--- a/src/app/api/ns/[nsId]/services/accounts/[accountId]/groups/[groupId]/members/getMembers.ts
+++ b/src/app/api/ns/[nsId]/services/accounts/[accountId]/groups/[groupId]/members/getMembers.ts
@@ -122,7 +122,11 @@ const getDiscordMembers = async (
   let maxUserId = 0;
   let requestResult: DiscordGuildMember[];
   const processedUserIds = new Set<string>();
+  let noChangeCount = 0;
+  const maxNoChangeCount = 2;
+
   do {
+    const previousMaxUserId = maxUserId;
     requestResult = await listGuildMembers(
       token,
       group.groupId as DiscordGuildId,
@@ -138,7 +142,22 @@ const getDiscordMembers = async (
     for (const member of filteredMembers) {
       processedUserIds.add(member.user.id);
     }
-    maxUserId = Math.max(...members.map((member) => Number(member.user.id)));
+
+    if (requestResult.length > 0) {
+      maxUserId = Number(requestResult[requestResult.length - 1].user.id);
+    }
+
+    // IDが変動しなかった場合のカウンターを更新
+    if (maxUserId === previousMaxUserId) {
+      noChangeCount++;
+    } else {
+      noChangeCount = 0;
+    }
+
+    // 2回連続でIDが変動しなかった場合は終了
+    if (noChangeCount >= maxNoChangeCount) {
+      break;
+    }
   } while (requestResult.length > 0);
   return members.map((member) => ({
     serviceId: member.user.id,

--- a/src/app/api/ns/[nsId]/services/accounts/[accountId]/groups/[groupId]/members/getMembers.ts
+++ b/src/app/api/ns/[nsId]/services/accounts/[accountId]/groups/[groupId]/members/getMembers.ts
@@ -119,7 +119,7 @@ const getDiscordMembers = async (
     JSON.parse(group.account.credential),
   ).token;
   const members: DiscordGuildMember[] = [];
-  let maxUserId = 0;
+  let maxUserId = "0";
   let requestResult: DiscordGuildMember[];
   const processedUserIds = new Set<string>();
   let noChangeCount = 0;
@@ -144,7 +144,7 @@ const getDiscordMembers = async (
     }
 
     if (requestResult.length > 0) {
-      maxUserId = Number(requestResult[requestResult.length - 1].user.id);
+      maxUserId = requestResult[requestResult.length - 1].user.id;
     }
 
     // IDが変動しなかった場合のカウンターを更新

--- a/src/lib/discord/requests/listGuildMembers.ts
+++ b/src/lib/discord/requests/listGuildMembers.ts
@@ -7,7 +7,7 @@ import type { DiscordToken } from "../types/token";
 
 type Options = {
   limit?: number;
-  after?: number;
+  after?: string;
 };
 
 export const listGuildMembers = async (
@@ -18,7 +18,7 @@ export const listGuildMembers = async (
   const query = new URLSearchParams(
     filterObject({
       limit: options.limit?.toString(),
-      after: options.after?.toString(),
+      after: options.after,
     } as Record<string, string>),
   );
   const response = await discordLimit(() =>


### PR DESCRIPTION
## 概要
Discordのメンバー取得で無限ループが発生する問題を修正しました。

## 問題
- Discord APIのページネーションで同じ\`after\`パラメータで繰り返しリクエストが送信される
- \`maxUserId\`の計算方法に問題があり、常に同じ値が設定されていた

## 修正内容
1. **ページネーションロジックの修正**
   - \`maxUserId\`を\`Math.max(...members.map(...))\`から\`requestResult[requestResult.length - 1].user.id\`に変更
   - これにより正しいページネーションが実現される

2. **安全装置の追加**
   - IDが変動しなかった場合のカウンター機能を実装
   - 2回連続でIDが変動しなかった場合は自動的にループを終了
   - これにより無限ループを完全に防止

## テスト
- [ ] Discordメンバー取得が正常に動作することを確認
- [ ] ページネーションが正しく動作することを確認
- [ ] 無限ループが発生しないことを確認

## 関連
- ログで確認された無限ループ問題の解決
- Discord APIのページネーション仕様に準拠